### PR TITLE
Fix function name mention in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ The filtering feature allows you to control which lines are included in the outp
 
 ## Customization
 
-You can adjust the speed of the progress bar by modifying the `time.Sleep(10 * time.Millisecond)` line in the `splitFile` function within the `split.go` file. Adjust the duration to control how quickly the progress bar updates.
+You can adjust the speed of the progress bar by modifying the `time.Sleep(10 * time.Millisecond)` line in the `SplitFile` function within the `split.go` file. Adjust the duration to control how quickly the progress bar updates.
 
 ## Acknowledgements
 


### PR DESCRIPTION
## Summary
- update README to mention `SplitFile` function

## Testing
- `go vet ./...` *(fails: missing go.sum entries)*

------
https://chatgpt.com/codex/tasks/task_e_6842cbc04cf883298f024d342da1db13